### PR TITLE
Warning: Operand of null-aware operation '!' has type 'Locale' which excludes null.

### DIFF
--- a/mapbox_gl_web/lib/src/mapbox_map_controller.dart
+++ b/mapbox_gl_web/lib/src/mapbox_map_controller.dart
@@ -110,7 +110,7 @@ class MapboxMapController extends MapboxGlPlatform
 
   @override
   Future<void> matchMapLanguageWithDeviceDefault() async {
-    setMapLanguage(ui.window.locale!.languageCode);
+    setMapLanguage(ui.window.locale.languageCode);
   }
 
   @override


### PR DESCRIPTION
#Warning detected 

```
mapbox_map_controller.dart:113:30: Warning: Operand of null-aware operation '!' has type 'Locale' which excludes null.
 - 'Locale' is from 'dart:ui'.
    setMapLanguage(ui.window.locale!.languageCode);
```